### PR TITLE
Ensure all primitives use textNumberPattern correctly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Run SonarCloud Scan
         if: ${{ env.SONARSCAN == 'true' }}
-        uses: sonarsource/sonarcloud-github-action@v1.8
+        uses: sonarsource/sonarcloud-github-action@v1.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/daffodil-codegen-c/src/test/resources/org/apache/daffodil/codegen/c/ex_nums.dfdl.xsd
+++ b/daffodil-codegen-c/src/test/resources/org/apache/daffodil/codegen/c/ex_nums.dfdl.xsd
@@ -138,7 +138,7 @@
                                         dfdl:byteOrder="littleEndian"/>
                             <xs:element name="le_int8" type="xs:byte"
                                         dfdl:byteOrder="littleEndian"/>
-                            <xs:element name="le_int46" type="xs:int"
+                            <xs:element name="le_int46" type="xs:integer"
                                         dfdl:byteOrder="littleEndian"
                                         dfdl:length="46"
                                         dfdl:lengthKind="explicit"/>

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/AnnotatedSchemaComponent.scala
@@ -19,6 +19,7 @@ package org.apache.daffodil.core.dsom
 
 import scala.collection.mutable
 import scala.xml.Node
+import scala.xml.NodeSeq
 
 import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.equality._
@@ -412,9 +413,8 @@ trait AnnotatedMixin { self: AnnotatedSchemaComponent =>
 
   private def isDfdlNamespace(ns: String): Boolean = ns.contains("ogf") && ns.contains("dfdl")
 
-  lazy val dfdlAppInfos = {
-    val ais = (annotationNode \ "appinfo")
-    val dais = ais.filter { ai =>
+  def getDFDLAppinfos(appinfos: NodeSeq): NodeSeq = {
+    val dais = appinfos.filter { ai =>
       {
         ai.attribute("source") match {
           case None => {
@@ -459,6 +459,11 @@ trait AnnotatedMixin { self: AnnotatedSchemaComponent =>
       }
     }
     dais
+  }
+
+  lazy val dfdlAppInfos = {
+    val ais = (annotationNode \ "appinfo")
+    getDFDLAppinfos(ais)
   }
 
   /**

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
@@ -141,7 +141,7 @@ sealed abstract class GlobalGroupDef(
     if (dais.nonEmpty)
       SDW(
         WarnID.InvalidAnnotationPoint,
-        "Annotations placed directly on a group definition will be ignored by DFDL. Any annotation expected to be processed by DFDL should instead be placed on the group reference, sequence or choice."
+        "Annotations placed directly on a group definition will be ignored by DFDL. Any annotation expected to be processed by DFDL should instead be placed on the group reference, sequence or choice.",
       )
   }
 

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/dsom/GroupDef.scala
@@ -21,6 +21,7 @@ import scala.xml.Comment
 import scala.xml.Node
 import scala.xml.Text
 
+import org.apache.daffodil.lib.api.WarnID
 import org.apache.daffodil.lib.exceptions.Assert
 
 object GlobalGroupDef {
@@ -118,6 +119,7 @@ sealed abstract class GlobalGroupDef(
 
   def groupMembers = {
     validateChoiceBranchKey()
+    checkForGroupDefAnnotations()
     this.groupMembersNotShared
   }
 
@@ -129,6 +131,18 @@ sealed abstract class GlobalGroupDef(
         "dfdl:choiceBranchKey cannot be specified on the choice/sequence child of a global group definition",
       )
     }
+  }
+
+  private def checkForGroupDefAnnotations(): Unit = {
+    // Ensure that the group definition itself does not have any annotations.
+    // Annotations should only be on group references or children of the group
+    // definition
+    val dais = getDFDLAppinfos(defXML \ "annotation" \ "appinfo")
+    if (dais.nonEmpty)
+      SDW(
+        WarnID.InvalidAnnotationPoint,
+        "Annotations placed directly on a group definition will be ignored by DFDL. Any annotation expected to be processed by DFDL should instead be placed on the group reference, sequence or choice."
+      )
   }
 
   final override lazy val name = defXML

--- a/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesZoned.scala
+++ b/daffodil-core/src/main/scala/org/apache/daffodil/core/grammar/primitives/PrimitivesZoned.scala
@@ -179,7 +179,6 @@ case class ConvertZonedNumberPrim(e: ElementBase)
       roundingMode,
       roundingIncrement,
       Nil,
-      isInt = true,
       e.primType,
     )
     ev.compile(tunable)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertTextStandardNumberUnparser.scala
@@ -59,7 +59,7 @@ case class ConvertTextNumberUnparser(
   override def unparse(state: UState): Unit = {
 
     val node = state.currentInfosetNode.asSimple
-    val value = node.dataValue.getAnyRef
+    val value = node.dataValue.getNumber
 
     // The type of value should have the type of S, but type erasure makes this
     // difficult to assert. Could probably check this with TypeTags or Manifest

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/ConvertZonedNumberUnparser.scala
@@ -64,9 +64,9 @@ case class ConvertZonedNumberUnparser(
     // if we find this is not the case. Want something akin to:
     // Assert.invariant(value.isInstanceOf[S])
 
-    val valueAsAnyRef = node.dataValue.getAnyRef
+    val number = node.dataValue.getNumber
 
-    val scaledNum = this.applyTextDecimalVirtualPointForUnparse(valueAsAnyRef)
+    val scaledNum = this.applyTextDecimalVirtualPointForUnparse(number)
 
     val value = scaledNum.toString
 

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SeparatedSequenceUnparsers.scala
@@ -111,7 +111,7 @@ class RepOrderedSeparatedSequenceChildUnparser(
   with Separated {
 
   override def checkArrayPosAgainstMaxOccurs(state: UState) =
-    state.arrayPos <= maxRepeats(state)
+    state.arrayIterationPos <= maxRepeats(state)
 }
 
 class OrderedSeparatedSequenceUnparser(
@@ -316,7 +316,8 @@ class OrderedSeparatedSequenceUnparser(
       val zlDetector = childUnparser.zeroLengthDetector
       childUnparser match {
         case unparser: RepOrderedSeparatedSequenceChildUnparser => {
-          state.arrayIndexStack.push(1L)
+          state.arrayIterationIndexStack.push(1L)
+          state.occursIndexStack.push(1L)
           val erd = unparser.erd
           var numOccurrences = 0
           val maxReps = unparser.maxRepeats(state)
@@ -357,8 +358,11 @@ class OrderedSeparatedSequenceUnparser(
                   // These are so we can check invariants on these stacks being
                   // pushed and popped reliably, and incremented only once
                   //
-                  val arrayIndexBefore = state.arrayPos
-                  val arrayIndexStackDepthBefore = state.arrayIndexStack.length
+                  val arrayIterationIndexBefore = state.arrayIterationPos
+                  val arrayIterationIndexStackDepthBefore =
+                    state.arrayIterationIndexStack.length
+                  val occursIndexBefore = state.occursPos
+                  val occursIndexStackDepthBefore = state.occursIndexStack.length
                   val groupIndexBefore = state.groupPos
                   val groupIndexStackDepthBefore = state.groupIndexStack.length
 
@@ -388,9 +392,15 @@ class OrderedSeparatedSequenceUnparser(
                     )
                   }
                   numOccurrences += 1
-                  Assert.invariant(state.arrayIndexStack.length == arrayIndexStackDepthBefore)
-                  state.moveOverOneArrayIndexOnly()
-                  Assert.invariant(state.arrayPos == arrayIndexBefore + 1)
+                  Assert.invariant(
+                    state.arrayIterationIndexStack.length == arrayIterationIndexStackDepthBefore,
+                  )
+                  state.moveOverOneArrayIterationIndexOnly()
+                  Assert.invariant(state.arrayIterationPos == arrayIterationIndexBefore + 1)
+
+                  Assert.invariant(state.occursIndexStack.length == occursIndexStackDepthBefore)
+                  state.moveOverOneOccursIndexOnly()
+                  Assert.invariant(state.occursPos == occursIndexBefore + 1)
 
                   Assert.invariant(state.groupIndexStack.length == groupIndexStackDepthBefore)
                   state.moveOverOneGroupIndexOnly() // array elements are always represented.
@@ -413,7 +423,7 @@ class OrderedSeparatedSequenceUnparser(
                   unparser,
                   numOccurrences,
                   maxReps,
-                  state.arrayPos - 1,
+                  state.arrayIterationPos - 1,
                 )
                 unparser.endArrayOrOptional(erd, state)
               } else {
@@ -467,7 +477,8 @@ class OrderedSeparatedSequenceUnparser(
             // no event (state.inspect returned false)
             Assert.invariantFailed("No event for unparsing.")
           }
-          state.arrayIndexStack.pop()
+          state.arrayIterationIndexStack.pop()
+          state.occursIndexStack.pop()
         }
         case scalarUnparser =>
           trd match {
@@ -564,7 +575,8 @@ class OrderedSeparatedSequenceUnparser(
               trailingSuspendedOps,
               onlySeparatorFlag = true,
             )
-            state.moveOverOneArrayIndexOnly()
+            state.moveOverOneArrayIterationIndexOnly()
+            state.moveOverOneOccursIndexOnly()
             state.moveOverOneGroupIndexOnly()
             numOccurrences += 1
           }
@@ -595,7 +607,8 @@ class OrderedSeparatedSequenceUnparser(
       //
       childUnparser match {
         case unparser: RepOrderedSeparatedSequenceChildUnparser => {
-          state.arrayIndexStack.push(1L)
+          state.arrayIterationIndexStack.push(1L)
+          state.occursIndexStack.push(1L)
           val erd = unparser.erd
           var numOccurrences = 0
           val maxReps = unparser.maxRepeats(state)
@@ -628,8 +641,11 @@ class OrderedSeparatedSequenceUnparser(
                   // These are so we can check invariants on these stacks being
                   // pushed and popped reliably, and incremented only once
                   //
-                  val arrayIndexBefore = state.arrayPos
-                  val arrayIndexStackDepthBefore = state.arrayIndexStack.length
+                  val arrayIterationIndexBefore = state.arrayIterationPos
+                  val arrayIterationIndexStackDepthBefore =
+                    state.arrayIterationIndexStack.length
+                  val occursIndexBefore = state.occursPos
+                  val occursIndexStackDepthBefore = state.occursIndexStack.length
                   val groupIndexBefore = state.groupPos
                   val groupIndexStackDepthBefore = state.groupIndexStack.length
 
@@ -643,9 +659,15 @@ class OrderedSeparatedSequenceUnparser(
 
                   unparseOne(unparser, erd, state)
                   numOccurrences += 1
-                  Assert.invariant(state.arrayIndexStack.length == arrayIndexStackDepthBefore)
-                  state.moveOverOneArrayIndexOnly()
-                  Assert.invariant(state.arrayPos == arrayIndexBefore + 1)
+                  Assert.invariant(
+                    state.arrayIterationIndexStack.length == arrayIterationIndexStackDepthBefore,
+                  )
+                  state.moveOverOneArrayIterationIndexOnly()
+                  Assert.invariant(state.arrayIterationPos == arrayIterationIndexBefore + 1)
+
+                  Assert.invariant(state.occursIndexStack.length == occursIndexStackDepthBefore)
+                  state.moveOverOneOccursIndexOnly()
+                  Assert.invariant(state.occursPos == occursIndexBefore + 1)
 
                   Assert.invariant(state.groupIndexStack.length == groupIndexStackDepthBefore)
                   state.moveOverOneGroupIndexOnly() // array elements are always represented.
@@ -670,7 +692,7 @@ class OrderedSeparatedSequenceUnparser(
                   unparser,
                   numOccurrences,
                   maxReps,
-                  state.arrayPos - 1,
+                  state.arrayIterationPos - 1,
                 )
                 unparser.endArrayOrOptional(erd, state)
               } else {
@@ -704,7 +726,8 @@ class OrderedSeparatedSequenceUnparser(
             // no event (state.inspect returned false)
             Assert.invariantFailed("No event for unparsing.")
           }
-          state.arrayIndexStack.pop()
+          state.arrayIterationIndexStack.pop()
+          state.occursIndexStack.pop()
         }
         case scalarUnparser => {
           unparseOne(scalarUnparser, trd, state)

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/SpecifiedLengthUnparsers.scala
@@ -225,7 +225,6 @@ final class SpecifiedLengthExplicitImplicitUnparser(
    * will be provided in bits.
    */
   def unparseBits(state: UState): Unit = {
-
     val maybeTLBits = getMaybeTL(state, targetLengthInBitsEv)
 
     if (maybeTLBits.isDefined) {

--- a/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
+++ b/daffodil-runtime1-unparser/src/main/scala/org/apache/daffodil/unparsers/runtime1/UnseparatedSequenceUnparsers.scala
@@ -46,7 +46,7 @@ class RepOrderedUnseparatedSequenceChildUnparser(
 
   override def checkArrayPosAgainstMaxOccurs(state: UState): Boolean = {
     if (ock eq OccursCountKind.Implicit)
-      state.arrayPos <= maxRepeats(state)
+      state.arrayIterationPos <= maxRepeats(state)
     else
       true
   }
@@ -92,7 +92,8 @@ class OrderedUnseparatedSequenceUnparser(
       //
       childUnparser match {
         case unparser: RepeatingChildUnparser => {
-          state.arrayIndexStack.push(1L)
+          state.arrayIterationIndexStack.push(1L)
+          state.occursIndexStack.push(1L)
           val erd = unparser.erd
           var numOccurrences = 0
           val maxReps = unparser.maxRepeats(state)
@@ -127,7 +128,8 @@ class OrderedUnseparatedSequenceUnparser(
 
                   unparseOne(unparser, erd, state)
                   numOccurrences += 1
-                  state.moveOverOneArrayIndexOnly()
+                  state.moveOverOneArrayIterationIndexOnly()
+                  state.moveOverOneOccursIndexOnly()
                   state.moveOverOneGroupIndexOnly() // array elements are always represented.
 
                   if (isArr)
@@ -140,7 +142,7 @@ class OrderedUnseparatedSequenceUnparser(
                   unparser,
                   numOccurrences,
                   maxReps,
-                  state.arrayPos - 1,
+                  state.arrayIterationPos - 1,
                 )
                 unparser.endArrayOrOptional(erd, state)
               } else {
@@ -179,7 +181,8 @@ class OrderedUnseparatedSequenceUnparser(
             Assert.invariantFailed("No event for unparing.")
           }
 
-          state.arrayIndexStack.pop()
+          state.arrayIterationIndexStack.pop()
+          state.occursIndexStack.pop()
         }
         //
         case scalarUnparser => {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/debugger/InteractiveDebugger.scala
@@ -1837,7 +1837,7 @@ class InteractiveDebugger(
         val longDesc = desc
 
         def getSomeValue(state: StateForDebugger): Option[Long] = {
-          if (state.arrayPos != -1) Some(state.arrayPos) else None
+          if (state.occursPos != -1) Some(state.occursPos) else None
         }
       }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/ArrayRelated.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/ArrayRelated.scala
@@ -17,7 +17,6 @@
 
 package org.apache.daffodil.runtime1.dpath
 
-import org.apache.daffodil.lib.exceptions.Assert
 import org.apache.daffodil.lib.util.Maybe.Nope
 import org.apache.daffodil.runtime1.infoset.InfosetNoInfosetException
 
@@ -79,9 +78,9 @@ case object FNExactlyOne extends RecipeOp {
 
 case object DFDLOccursIndex extends RecipeOp {
   override def run(dstate: DState): Unit = {
-    Assert.invariant(dstate.arrayPos >= 1)
-    if (dstate.isCompile)
+    if (dstate.isCompile) {
       throw new InfosetNoInfosetException(Nope)
-    dstate.setCurrentValue(dstate.arrayPos)
+    }
+    dstate.setCurrentValue(dstate.occursIndex)
   }
 }

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DPathRuntime.scala
@@ -63,7 +63,7 @@ class CompiledDPath(val ops: RecipeOp*) extends Serializable {
       dstate.setContextNode(state.thisElement.asInstanceOf[DINode]) // used for diagnostics
     }
 
-    dstate.setArrayPos(state.arrayPos)
+    dstate.setOccursIndex(state.occursPos)
     dstate.setErrorOrWarn(state)
     dstate.resetValue
     dstate.isCompile = state match {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/DState.scala
@@ -367,10 +367,10 @@ case class DState(
     _savesErrorsAndWarnings = One(s)
   }
 
-  private var _arrayPos: Long = -1L // init to -1L so that we must set before use.
-  def arrayPos = _arrayPos
-  def setArrayPos(arrayPos1b: Long): Unit = {
-    _arrayPos = arrayPos1b
+  private var _occursIndex: Long = -1
+  def occursIndex = _occursIndex
+  def setOccursIndex(index: Long): Unit = {
+    _occursIndex = index
   }
 
   def SDE(formatString: String, args: Any*) = {
@@ -450,7 +450,6 @@ class DStateForConstantFolding(
   override def runtimeData = die
   override def selfMove() = die
   override def fnExists() = die
-  override def arrayPos = die
   override def arrayLength = die
   override val typeCalculators = compileInfo.typeCalcMap
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/dpath/NodeInfo.scala
@@ -704,7 +704,13 @@ object NodeInfo extends Enum {
       type Kind = DecimalKind
       protected override def fromString(s: String): DataValueBigDecimal = new JBigDecimal(s)
       protected override def fromNumberNoCheck(n: Number): DataValueBigDecimal = asBigDecimal(n)
-      override def isValid(n: Number): Boolean = true
+      override def isValid(n: Number): Boolean = {
+        n match {
+          case d: JDouble if d.isInfinite || d.isNaN => false
+          case f: JFloat if f.isInfinite || f.isNaN => false
+          case _ => true
+        }
+      }
 
       override val width: MaybeInt = MaybeInt.Nope
 
@@ -720,7 +726,13 @@ object NodeInfo extends Enum {
       type Kind = IntegerKind
       protected override def fromString(s: String): DataValueBigInt = new JBigInt(s)
       protected override def fromNumberNoCheck(n: Number): DataValueBigInt = asBigInt(n)
-      override def isValid(n: Number): Boolean = true
+      override def isValid(n: Number): Boolean = {
+        n match {
+          case d: JDouble if d.isInfinite || d.isNaN => false
+          case f: JFloat if f.isInfinite || f.isNaN => false
+          case _ => true
+        }
+      }
 
       override val width: MaybeInt = MaybeInt.Nope
 
@@ -795,6 +807,8 @@ object NodeInfo extends Enum {
       def isValid(n: Number): Boolean = n match {
         case bd: JBigDecimal => bd.signum >= 0
         case bi: JBigInt => bi.signum >= 0
+        case d: JDouble if d.isInfinite || d.isNaN => false
+        case f: JFloat if f.isInfinite || f.isNaN => false
         case _ => n.longValue >= 0
       }
 
@@ -815,6 +829,8 @@ object NodeInfo extends Enum {
       def isValid(n: Number): Boolean = n match {
         case bd: JBigDecimal => bd.signum >= 0 && bd.compareTo(maxBD) <= 0
         case bi: JBigInt => bi.signum >= 0 && bi.compareTo(max) <= 0
+        case d: JDouble if d.isInfinite || d.isNaN => false
+        case f: JFloat if f.isInfinite || f.isNaN => false
         case _ => n.longValue >= 0
       }
       val max = new JBigInt(1, scala.Array.fill(8)(0xff.toByte))

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/Infoset.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/Infoset.scala
@@ -31,7 +31,6 @@ trait InfosetArray {
   def append(ie: InfosetElement): Unit
   def getOccurrence(occursIndex: Long): InfosetElement
   def length: Long
-
 }
 
 trait InfosetElement extends InfosetItem {

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/infoset/InfosetImpl.scala
@@ -23,7 +23,6 @@ import java.math.{ BigDecimal => JBigDecimal }
 import java.util.HashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
-import scala.collection.IndexedSeq
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.daffodil.io.DataOutputStream

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/DataProcessor.scala
@@ -587,7 +587,8 @@ class DataProcessor(
     state.setProcessor(rootUnparser)
 
     // Verify that all stacks are empty
-    Assert.invariant(state.arrayIndexStack.length == 1)
+    Assert.invariant(state.arrayIterationIndexStack.length == 1)
+    Assert.invariant(state.occursIndexStack.length == 1)
     Assert.invariant(state.groupIndexStack.length == 1)
     Assert.invariant(state.childIndexStack.length == 1)
     Assert.invariant(state.currentInfosetNodeMaybe.isEmpty)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/EvTextNumber.scala
@@ -81,7 +81,6 @@ class TextNumberFormatEv(
   roundingMode: Maybe[TextNumberRoundingMode],
   roundingIncrement: MaybeDouble,
   zeroRepsRaw: List[String],
-  isInt: Boolean,
   primType: PrimType,
 ) extends Evaluatable[DecimalFormat](tci)
   with InfosetCachedEvaluatable[DecimalFormat] {
@@ -161,6 +160,11 @@ class TextNumberFormatEv(
       case TextNumberCheckPolicy.Lax => false
     }
     df.setParseStrict(cp)
+    // if strict mode is enabled, we also enable setDecimalPatternMatchRequired. This says that
+    // if a decimal point is in the pattern, then the data must contain a decimal point. It also
+    // says the reverse, that if a decimal point is not in the pattern, then the data cannot
+    // contain a decimal point.
+    df.setDecimalPatternMatchRequired(cp)
 
     rounding match {
       case TextNumberRounding.Pattern => {
@@ -180,13 +184,6 @@ class TextNumberFormatEv(
         df.setRoundingMode(rm.ordinal())
         df.setRoundingIncrement(roundingIncrement.get)
       }
-    }
-
-    if (isInt) {
-      df.setMaximumFractionDigits(0)
-      df.setDecimalSeparatorAlwaysShown(false)
-      df.setParseIntegerOnly(true)
-      df.setParseBigDecimal(false)
     }
 
     df

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/ProcessorStateBases.scala
@@ -70,7 +70,8 @@ trait StateForDebugger {
   def bitLimit0b: MaybeULong
   def childPos: Long
   def groupPos: Long
-  def arrayPos: Long
+  def arrayIterationPos: Long
+  def occursPos: Long
   def variableMapForDebugger: VariableMap
   def delimitedParseResult: Maybe[dfa.ParseResult]
   def withinHiddenNest: Boolean
@@ -83,7 +84,8 @@ case class TupleForDebugger(
   val bitLimit0b: MaybeULong,
   val childPos: Long,
   val groupPos: Long,
-  val arrayPos: Long,
+  val arrayIterationPos: Long,
+  val occursPos: Long,
   val variableMapForDebugger: VariableMap,
   val delimitedParseResult: Maybe[dfa.ParseResult],
   val withinHiddenNest: Boolean,
@@ -473,7 +475,8 @@ abstract class ParseOrUnparseState protected (
       bitLimit0b,
       childPos,
       groupPos,
-      arrayPos,
+      arrayIterationPos,
+      occursPos,
       variableMap.copy(), // deep copy since variableMap is mutable
       delimitedParseResult,
       withinHiddenNest,
@@ -506,7 +509,8 @@ abstract class ParseOrUnparseState protected (
   final def bytePos = bytePos0b
 
   def groupPos: Long
-  def arrayPos: Long
+  def arrayIterationPos: Long
+  def occursPos: Long
   def childPos: Long
 
   def hasInfoset: Boolean
@@ -604,7 +608,8 @@ final class CompileState(
   tunable: DaffodilTunables,
 ) extends ParseOrUnparseState(tci.variableMap, Nil, maybeDataProc, tunable) {
 
-  def arrayPos: Long = 1L
+  def arrayIterationPos: Long = 1L
+  def occursPos: Long = 1L
   def bitLimit0b: MaybeULong = MaybeULong.Nope
   def bitPos0b: Long = 0L
   def childPos: Long = 0L

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/RuntimeData.scala
@@ -390,7 +390,7 @@ final class SimpleTypeRuntimeData(
       }
     }
 
-    // Note: dont check occurs counts // if(!checkMinMaxOccurs(e, pstate.arrayPos)) { return java.lang.Boolean.FALSE }
+    // Note: dont check occurs counts // if(!checkMinMaxOccurs(e, pstate.arrayIterationPos)) { return java.lang.Boolean.FALSE }
     OK
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/BinaryNumberParsers.scala
@@ -167,6 +167,16 @@ abstract class BinaryIntegerBaseParser(
   def parse(start: PState): Unit = {
     val nBits = getBitLength(start)
     if (nBits == 0) return // zero length is used for outputValueCalc often.
+    if (primNumeric.width.isDefined) {
+      val width = primNumeric.width.get
+      if (nBits > width)
+        PE(
+          start,
+          "Number of bits %d out of range, must be between 1 and %d bits.",
+          nBits,
+          width,
+        )
+    }
     val dis = start.dataInputStream
     if (!dis.isDefinedForLength(nBits)) {
       PENotEnoughBits(start, nBits, dis.remainingBits)

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/ConvertTextStandardNumberParser.scala
@@ -20,6 +20,7 @@ package org.apache.daffodil.runtime1.processors.parsers
 import java.lang.{ Double => JDouble, Float => JFloat, Long => JLong, Number => JNumber }
 import java.math.MathContext
 import java.math.{ BigDecimal => JBigDecimal }
+import java.math.{ BigInteger => JBigInteger }
 import java.text.ParsePosition
 import scala.util.matching.Regex
 
@@ -61,36 +62,45 @@ trait TextDecimalVirtualPointMixin {
   final protected lazy val virtualPointScaleFactor =
     scala.math.pow(10.0, textDecimalVirtualPoint)
 
-  final protected def applyTextDecimalVirtualPointForParse(num1: JNumber): JNumber = {
-    if (textDecimalVirtualPoint == 0) num1
+  final protected def applyTextDecimalVirtualPointForParse(num: JNumber): JNumber = {
+    if (textDecimalVirtualPoint == 0) num
     else {
       // scale for virtual decimal point
-      val scaledNum: JNumber = num1 match {
-        // Empirically, in our test suite, we do get Long back here, so the runtime sometimes represents small integer
-        // (or possibly even smaller decimal numbers with no fraction part) as Long.
+      val scaledNum: JNumber = num match {
         case l: JLong => {
+          // For integers that can fit in a long, ICU will always return a long
           val scaled = JBigDecimal.valueOf(l).scaleByPowerOfTen(-textDecimalVirtualPoint)
           if (textDecimalVirtualPoint < 0) scaled.toBigIntegerExact()
           else scaled
         }
-        case bd: JBigDecimal => bd.scaleByPowerOfTen(-textDecimalVirtualPoint)
-        case f: JFloat => (f / virtualPointScaleFactor).toFloat
-        case d: JDouble => (d / virtualPointScaleFactor).toDouble
+        case bi: JBigInteger => {
+          // For numbers that cannot fit into a long but do not have a decimal, ICU will return
+          // a BigDecimal which we converted to a BigInteger. Convert back to a BigDecimal so it
+          // can be scaled
+          val bd = new JBigDecimal(bi)
+          bd.scaleByPowerOfTen(-textDecimalVirtualPoint)
+        }
+        case d: JDouble => {
+          // ICU only returns doubles if they are infinity/NaN, these cannot be scaled
+          Assert.invariant(d.isNaN || d.isInfinite)
+          d
+        }
         // $COVERAGE-OFF$
-        case _ => badType(num1)
+        case _ => {
+          // ICU returns either Long, Double (for inf/nan) or BigDecimal. BigDecimal should have
+          // been converted to BigInteger if possible, and if not it should have created a PE
+          // since we have a virtual point. If we see any other types, it means ICU returned
+          // something unexpected or we didn't throw a PE correctly.
+          Assert.invariantFailed(s"""
+            |Number cannot be scaled for virtual decimal point,
+            |expected integer type but got ${num.getClass.getSimpleName}.
+            """.stripMargin)
+        }
         // $COVERAGE-ON$
       }
       scaledNum
     }
   }
-
-  // $COVERAGE-OFF$
-  private def badType(num1: AnyRef) = {
-    Assert.invariantFailed(s"""Number cannot be scaled for virtual decimal point,
-         |because it is not a decimal, float, or double.
-         |The type is ${num1.getClass.getSimpleName}.""".stripMargin)
-  }
-  // $COVERAGE-ON$
 
   /**
    * Always creates an integer from a JFloat, JDouble, or JBigDecimal
@@ -103,11 +113,11 @@ trait TextDecimalVirtualPointMixin {
    *
    * Floating point NaNs and Infinities are tolerated. (No scaling occurs.)
    *
-   * @param valueAsAnyRef value to be scaled. Should be a JNumber. Aborts otherwise.
+   * @param value value to be scaled
    * @return a JNumber of the same concrete type as the argument.
    */
-  final protected def applyTextDecimalVirtualPointForUnparse(valueAsAnyRef: AnyRef): JNumber = {
-    val res: JNumber = valueAsAnyRef match {
+  final protected def applyTextDecimalVirtualPointForUnparse(value: JNumber): JNumber = {
+    val res: JNumber = value match {
       case jn: JNumber if (textDecimalVirtualPoint == 0) => jn
       // This is not perfectly symmetrical with the parse side equivalent.
       // Empirically in our test suite, we do not see JLong here.
@@ -127,16 +137,20 @@ trait TextDecimalVirtualPointMixin {
       case f: JFloat => (f * virtualPointScaleFactor).round.toFloat
       case d: JDouble if d.isNaN || d.isInfinite => d
       case d: JDouble => (d * virtualPointScaleFactor).round.toDouble
-      case bd: JBigDecimal =>
+      case bd: JBigDecimal => {
         bd.scaleByPowerOfTen(textDecimalVirtualPoint).round(MathContext.UNLIMITED)
-      case n: JNumber =>
-        // $COVERAGE-OFF$ // both badType and the next case are coverage-off
-        badType(n)
-      case _ => Assert.invariantFailed("Not a JNumber")
+      }
+      // $COVERAGE-OFF$
+      case _ => {
+        Assert.invariantFailed(s"""
+          |Number cannot be unscaled for virtual decimal point,
+          |expected decimal, float, or double, but got
+          |${value.getClass.getSimpleName}.""".stripMargin)
+      }
       // $COVERAGE-ON$
     }
     // Result type is same as argument type.
-    Assert.invariant(res.getClass == valueAsAnyRef.getClass)
+    Assert.invariant(res.getClass == value.getClass)
     res
   }
 }
@@ -171,47 +185,91 @@ case class ConvertTextStandardNumberParser(
       case Some(_) => primNumeric.fromNumber(0)
       case None => {
         val df = textNumberFormatEv.evaluate(start)
-        val strCheckPolicy = if (df.isParseStrict) str else str.trim
+        val strToParse = if (df.isParseStrict) str else str.trim
         val pos = new ParsePosition(0)
-        val icuNum: Number = df.parse(strCheckPolicy, pos) match {
+        val icuNum: JNumber = df.parse(strToParse, pos) match {
           case null => {
-            PE(
-              start,
-              "Unable to parse %s from text: %s",
-              context.optPrimType.get.globalQName,
-              str,
-            )
-            return
+            val infNaN: JDouble =
+              if (df.isDecimalPatternMatchRequired) {
+                // ICU failed to parse. But there is a bug in ICU4J (ICU-22303) that if there is
+                // a decimal in the pattern and we've set that decimal to be required (due to
+                // strict mode), then it will fail to parse Inf/NaN representations. As a
+                // workaround, we clone the DecimalFormat, disable requiring the decimal, and
+                // reparse. We only accept successful Inf/NaN parses though--everything else is
+                // considered a parse error since it meant the decimal point was missing or
+                // wasn't either inf/nan or a valid number. If ICU fixes this bug, we should
+                // remove this infNan variable and its use, as it is likely pretty expensive to
+                // clone, change a setting, and reparse. Fortunately, it is only in the error
+                // case of strict parsing so should be rare.
+                pos.setIndex(0)
+                val newDF = df.clone().asInstanceOf[DecimalFormat]
+                newDF.setDecimalPatternMatchRequired(false)
+                newDF.parse(strToParse, pos) match {
+                  case d: JDouble => {
+                    Assert.invariant(d.isNaN || d.isInfinite)
+                    d
+                  }
+                  case _ => null
+                }
+              } else {
+                null
+              }
+
+            if (infNaN != null) {
+              infNaN
+            } else {
+              PE(
+                start,
+                "Unable to parse %s from text: %s",
+                context.optPrimType.get.globalQName,
+                str,
+              )
+              return
+            }
           }
-          case d: JDouble if primNumeric.isInteger => {
-            // If ICU returns a Double when only integers are expected, it means the
-            // string must have been NaN, -Infinity, or Infinity using the locales
-            // default symbols. There does not seem to be a way to disable this even
-            // with setParseBigDecimal to false and setParseIntegerOnly set to true.
-            // So just create the same PE as if it failed to parse it, which is what
-            // we really want ICU to do
+          case d: JDouble => {
+            // ICU returns a Double only if it parsed NaN, Infinity, or -Infinity. We will later
+            // pass this value in primNumber.fromNumber, which will fail if the primitive type
+            // does not allow NaN/Infinity
             Assert.invariant(d.isNaN || d.isInfinite)
-            PE(
-              start,
-              "Unable to parse %s from text: %s",
-              context.optPrimType.get.globalQName,
-              str,
-            )
-            return
+            d
           }
           case bd: ICUBigDecimal => {
-            // sometimes ICU will return their own custom BigDecimal, even if the
-            // value could be represented as a BigInteger. We only want Java types,
-            // so detect this and convert it to the appropriate type
+            // ICU will return their own custom BigDecimal if the value cannot fit in a Long and
+            // isn't infinity/NaN. We only want Java types, so detect this and convert it to the
+            // appropriate type. Additionally, due to ICU lax parsing, ICU could successfully
+            // parse something with a non-zero fractional part even if the pattern does not
+            // specify a decimal. So in cases where decimals are not allowed (e.g. integer
+            // primitives, virtual decimal points), we create a PE.
+
+            val fractionalPartMustBeZero = primNumeric.isInteger || textDecimalVirtualPoint > 0
+
             if (bd.scale == 0) bd.unscaledValue
-            else bd.toBigDecimal
+            else if (!fractionalPartMustBeZero) {
+              bd.toBigDecimal
+            } else {
+              PE(
+                start,
+                "Unable to parse %s from text: %s",
+                context.optPrimType.get.globalQName,
+                str,
+              )
+              return
+            }
           }
-          case num: Number => num
+          case l: JLong => l
+          // $COVERAGE-OFF$
+          case num: JNumber => {
+            Assert.invariantFailed(
+              "ICU returned an unexpected type. Expected either Double, ICU BigDecimal, or Long, but got " + num.getClass.getName,
+            )
+          }
+          // $COVERAGE-ON$
         }
 
         // Verify that what was parsed was what was passed exactly in byte count.
         // Use pos to verify all characters consumed & check for errors!
-        if (pos.getIndex != strCheckPolicy.length) {
+        if (pos.getIndex != strToParse.length) {
           val isValid =
             if (df.getPadPosition == DecimalFormat.PAD_AFTER_SUFFIX) {
               // If the DecimalFormat pad position is PAD_AFTER_SUFFIX, ICU

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/InitiatedContentParsers.scala
@@ -27,7 +27,7 @@ final class InitiatedContentDiscrimOnIndexGreaterThanMinParser(
   override lazy val runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
-    if (start.arrayPos > min)
+    if (start.arrayIterationPos > min)
       start.resolvePointOfUncertainty()
   }
 }
@@ -47,7 +47,7 @@ final class InitiatedContentDiscrimChoiceOnlyOnFirstIndexParser(
   override lazy val runtimeDependencies = Vector()
 
   final def parse(start: PState): Unit = {
-    if (start.arrayPos == 1)
+    if (start.arrayIterationPos == 1)
       start.resolvePointOfUncertainty()
   }
 }
@@ -71,7 +71,7 @@ final class InitiatedContentDiscrimChoiceAndIndexGreaterThanMinParser(
     // branch and not to try any other branches if something in the array
     // fails.
 
-    if (start.arrayPos > min) {
+    if (start.arrayIterationPos > min) {
       // resolve the point of uncertainty associated with array elements once
       // we have parsed the required number of min occurrences. There should
       // not be a point of uncertainty associated with this array until we have
@@ -79,7 +79,7 @@ final class InitiatedContentDiscrimChoiceAndIndexGreaterThanMinParser(
       start.resolvePointOfUncertainty()
     }
 
-    if (start.arrayPos == 1) {
+    if (start.arrayIterationPos == 1) {
       // resolve the point of uncertainty associated with the initiated content
       // choice so we do not attempt to parse other branches if something fails
       start.resolvePointOfUncertainty()

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedParseHelper.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SeparatedParseHelper.scala
@@ -58,7 +58,7 @@ sealed abstract class SeparatorParseHelper(
           pstate,
           "Failed to populate %s[%s]. Missing %s separator. Cause: %s",
           erd.prefixedName,
-          pstate.mpstate.arrayPos,
+          pstate.mpstate.arrayIterationPos,
           kind,
           cause,
         )

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceChildBases.scala
@@ -291,7 +291,7 @@ abstract class RepeatingChildParser(
   def arrayIndexStatus(minRepeats: Long, maxRepeats: Long, pstate: PState): ArrayIndexStatus = {
     import ArrayIndexStatus._
     Assert.invariant(pstate.processorStatus eq Success)
-    val apos = pstate.arrayPos
+    val apos = pstate.arrayIterationPos
     val result: ArrayIndexStatus =
       if (apos <= minRepeats)
         Required
@@ -331,7 +331,8 @@ abstract class RepeatingChildParser(
    * there can be more than 1 occurrence.
    */
   def startArray(state: PState): Unit = {
-    state.mpstate.arrayIndexStack.push(1L) // one-based indexing
+    state.mpstate.arrayIterationIndexStack.push(1L) // one-based indexing
+    state.mpstate.occursIndexStack.push(1L)
   }
 
   /**
@@ -344,7 +345,8 @@ abstract class RepeatingChildParser(
    * by way of index: e.g., fn:exists( optElement[dfdl:currentIndex()]  )
    */
   def endArray(state: PState): Unit = {
-    state.mpstate.arrayIndexStack.pop()
+    state.mpstate.arrayIterationIndexStack.pop()
+    state.mpstate.occursIndexStack.pop()
     super.endArray(state)
   }
 

--- a/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
+++ b/daffodil-runtime1/src/main/scala/org/apache/daffodil/runtime1/processors/parsers/SequenceParserBases.scala
@@ -46,7 +46,7 @@ abstract class SequenceParserBase(
   import ParseAttemptStatus._
 
   final protected def checkN(pstate: PState, childParser: SequenceChildParser): Unit = {
-    if (pstate.arrayPos > pstate.tunable.maxOccursBounds) {
+    if (pstate.arrayIterationPos > pstate.tunable.maxOccursBounds) {
       throw new TunableLimitExceededError(
         childParser.trd.schemaFileLocation,
         "Array occurrences excceeds the maxOccursBounds tunable limit of %s",
@@ -187,11 +187,17 @@ abstract class SequenceParserBase(
               // advance array position.
               // Done unconditionally, as some failures get converted into successes
               //
-              // If ultimately this is a real failure, then mothing cares about this, it is
-              // about to get poppped/cleared anyway.
+              // If ultimately this is a real failure, then nothing cares about this, it is
+              // about to get popped/cleared anyway.
               //
               if (ais ne Done) {
-                pstate.mpstate.moveOverOneArrayIndexOnly()
+                pstate.mpstate.moveOverOneArrayIterationIndexOnly()
+
+                // If the emptyElementParsePolicy is set to treatAsAbsent, don't
+                // increment the occursIndex if the element is absent
+                if (resultOfTry != AbsentRep) {
+                  pstate.mpstate.moveOverOneOccursIndexOnly()
+                }
               }
 
               if (
@@ -509,7 +515,7 @@ abstract class SequenceParserBase(
                 pstate,
                 "Failed to populate %s[%s]. Cause: %s",
                 erd.prefixedName,
-                pstate.mpstate.arrayPos,
+                pstate.mpstate.arrayIterationPos,
                 cause,
               )
             }

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.dfdl.xsd
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.dfdl.xsd
@@ -75,7 +75,7 @@
       <sequence dfdl:separator="***" dfdl:terminator="%NL;">
         <element name="z" type="xsd:float" maxOccurs="unbounded"
           dfdl:lengthKind="delimited" dfdl:textNumberJustification="right"
-          dfdl:textNumberPattern="####"
+          dfdl:textNumberPattern="####.#"
           dfdl:textNumberPadCharacter="%SP;" />
       </sequence>
     </sequence>

--- a/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.tdml
+++ b/daffodil-test-ibm1/src/test/resources/test-suite/tresys-contributed/BG.tdml
@@ -23,9 +23,9 @@
 
   <parserTestCase name="BG000" root="list" model="BG.dfdl.xsd"
     description="Text number properties">
-    <document><![CDATA[    9#876#543#210!01***   12#345!6*** 123456789123456789*** INFINITO***    NNN***   ZERO*** NA*** NIL
+    <document><![CDATA[    9#876#543#210!01***   12#345!6*** 123456789123456789!0*** INFINITO***    NNN***   ZERO*** NA*** NIL
   aabbccddeeff*** 0f0f0f*** 123456789
-  10.1*** 20.3***   -912^-13
+  10.1*** 20.3***   -91.2^-12
 ]]></document>
     <infoset>
       <dfdlInfoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section05/simple_types/SimpleTypes.tdml
@@ -216,7 +216,7 @@
 
     <xs:element name="posint01" type="xs:nonNegativeInteger" />
     <xs:element name="int01" type="xs:int" />
-    <xs:element name="int02" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="65" />
+    <xs:element name="int02" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="16" />
     <xs:element name="l_1" type="xs:long" />
     <xs:element name="s_1" type="xs:short" />
     <xs:element name="b_01" type="xs:byte" />

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section07/variables/variables.tdml
@@ -2708,4 +2708,51 @@
     </tdml:infoset>
   </tdml:parserTestCase>
 
+  <tdml:defineSchema name="nviInGroupDecl">
+
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+
+    <dfdl:defineVariable defaultValue="x" name="var1" type="xs:string"/>
+
+    <dfdl:format ref="GeneralFormat" />
+
+    <xs:group name="g1">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:newVariableInstance ref="ex:var1" defaultValue="test"/>
+        </xs:appinfo>
+      </xs:annotation>
+      <xs:sequence>
+        <xs:element name="e1" type="xs:string" dfdl:inputValueCalc="{ $ex:var1 }"/>
+      </xs:sequence>
+    </xs:group>
+
+    <xs:element name="root">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:group ref="ex:g1"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="nviInGroupDecl_01" root="root" model="nviInGroupDecl">
+    <tdml:document></tdml:document>
+    <tdml:warnings>
+      <tdml:warning>Schema Definition Warning</tdml:warning>
+      <tdml:warning>Annotations</tdml:warning>
+      <tdml:warning>group definition</tdml:warning>
+      <tdml:warning>ignored</tdml:warning>
+    </tdml:warnings>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <root>
+          <e1>x</e1>
+        </root>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/ExplicitTests.tdml
@@ -831,7 +831,7 @@
     <dfdl:format ref="ex:GeneralFormat" />
 
     <xs:element name="stringy" type="xs:string" dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:length="6"/>
-    <xs:element name="inty" type="xs:int" dfdl:representation="binary" dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:length="6"/>
+    <xs:element name="inty" type="xs:integer" dfdl:representation="binary" dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:length="6"/>
     <xs:element name="inty02" type="xs:int" dfdl:representation="binary" dfdl:lengthUnits="bytes" dfdl:lengthKind="explicit" dfdl:length="2"/>
 
   </tdml:defineSchema>
@@ -1048,6 +1048,294 @@
       <tdml:warning>lengthUnits='bits'</tdml:warning>
       <tdml:warning>will only be supported</tdml:warning>
     </tdml:warnings>
+  </tdml:parserTestCase>
+
+  <!--
+    These tests check for the condition where the bit length exceeds the width of the
+    specified type when the value is a constant. All numeric signed and unsigned types are checked
+    using invalid bit lengths, and there is one check for an invalid byte length.
+  -->
+  <tdml:defineSchema name="invalidUnsignedLongBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:unsignedLong" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="128"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedLongBitLength" root="r" model="invalidUnsignedLongBitLength"
+                       description="Check for invalid bit length with an unsigned long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedLongByteLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:unsignedLong" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes" dfdl:length="16"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedLongByteLength" root="r" model="invalidUnsignedLongByteLength"
+                       description="Check for invalid byte length with an unsigned long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedIntBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:unsignedInt" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="64"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedIntBitLength" root="r" model="invalidUnsignedIntBitLength"
+                       description="Check for invalid bit length with an unsigned int">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>64 out of range</tdml:error>
+      <tdml:error>between 1 and 32</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedShortBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:unsignedShort" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="32"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedShortBitLength" root="r" model="invalidUnsignedShortBitLength"
+                       description="Check for invalid bit length with an unsigned short">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 out of range</tdml:error>
+      <tdml:error>between 1 and 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedByteBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:unsignedByte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="16"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedByteBitLength" root="r" model="invalidUnsignedByteBitLength"
+                       description="Check for invalid bit length with an unsigned byte">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>16 out of range</tdml:error>
+      <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidLongBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:long" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="128"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidLongBitLength" root="r" model="invalidLongBitLength"
+                       description="Check for invalid bit length with a signed long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidIntBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="64"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidIntBitLength" root="r" model="invalidIntBitLength"
+                       description="Check for invalid bit length with an signed in">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>64 out of range</tdml:error>
+      <tdml:error>between 1 and 32</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidShortBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:short" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="32"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidShortBitLength" root="r" model="invalidShortBitLength"
+                       description="Check for invalid bit length with a signed short">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 out of range</tdml:error>
+      <tdml:error>between 1 and 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidByteBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r" type="xs:byte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="16"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidByteBitLength" root="r" model="invalidByteBitLength"
+                       description="Check for invalid bit length with a signed byte">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>16 out of range</tdml:error>
+      <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <!--
+  These tests check for the condition where the bit length exceeds the width of the
+  specified type when the value is an expression. All numeric signed types are checked
+  using invalid bit lengths.
+  -->
+  <tdml:defineSchema name="invalidLongBitLengthExpr">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:unsignedByte"/>
+          <xs:element name="v" type="xs:long" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidLongBitLengthExpr" root="r" model="invalidLongBitLengthExpr"
+                       description="">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        80
+        ff ff ff ff
+        ff ff ff ff
+        ff ff ff ff
+        ff ff ff ff
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidIntBitLengthExpr">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:unsignedByte"/>
+          <xs:element name="v" type="xs:int" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidIntBitLengthExpr" root="r" model="invalidIntBitLengthExpr"
+                       description="">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        40
+        ff ff ff ff
+        ff ff ff ff
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>64 out of range</tdml:error>
+      <tdml:error>between 1 and 32</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidShortBitLengthExpr">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:unsignedByte"/>
+          <xs:element name="v" type="xs:short" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidShortBitLengthExpr" root="r" model="invalidShortBitLengthExpr"
+                       description="">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        20
+        ff ff ff ff
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 out of range</tdml:error>
+      <tdml:error>between 1 and 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidByteBitLengthExpr">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:element name="r">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="len" type="xs:unsignedByte"/>
+          <xs:element name="v" type="xs:byte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bits" dfdl:length="{ ../ex:len }"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:element>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidByteBitLengthExpr" root="r" model="invalidByteBitLengthExpr"
+                       description="">
+    <tdml:document>
+      <tdml:documentPart type="byte">
+        10
+        ff ff
+      </tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>16 out of range</tdml:error>
+      <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section12/lengthKind/PrefixedTests.tdml
@@ -407,7 +407,7 @@
 
     <xs:simpleType name="plSlash1_string_prefix"
        dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bytes">
-      <xs:restriction base="xs:unsignedByte" />
+      <xs:restriction base="xs:unsignedInt" />
     </xs:simpleType>
 
     <xs:element name="plSlash1_data">
@@ -2586,6 +2586,272 @@
       <tdml:warning>lengthUnits='bits'</tdml:warning>
       <tdml:warning>will only be supported</tdml:warning>
     </tdml:warnings>
+  </tdml:parserTestCase>
+
+  <!--
+  These tests check for the condition where the bit length exceeds the width of the
+  specified type when the value is a constant. All numeric signed and unsigned types are checked
+  using invalid bit lengths, and there is one check for an invalid byte length.
+  -->
+  <tdml:defineSchema name="invalidUnsignedLongBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedUnsignedLong"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="128">
+      <xs:restriction base="xs:unsignedLong"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:unsignedLong"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedUnsignedLong"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedLongBitLength" root="r" model="invalidUnsignedLongBitLength"
+                       description="Check for invalid bit length with an unsigned long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedLongByteLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedUnsignedLong"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bytes"
+                   dfdl:length="16">
+      <xs:restriction base="xs:unsignedLong"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:unsignedLong"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedUnsignedLong"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedLongByteLength" root="r" model="invalidUnsignedLongByteLength"
+                       description="Check for invalid byte length with an unsigned long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedIntBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedUnsignedInt"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="64">
+      <xs:restriction base="xs:unsignedInt"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:unsignedInt"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedUnsignedInt"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedIntBitLength" root="r" model="invalidUnsignedIntBitLength"
+                       description="Check for invalid bit length with an unsigned int">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>64 out of range</tdml:error>
+      <tdml:error>between 1 and 32</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedShortBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedUnsignedShort"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="32">
+      <xs:restriction base="xs:unsignedShort"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:unsignedShort"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedUnsignedShort"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedShortBitLength" root="r" model="invalidUnsignedShortBitLength"
+                       description="Check for invalid bit length with an unsigned short">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 out of range</tdml:error>
+      <tdml:error>between 1 and 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidUnsignedByteBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedUnsignedByte"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="16">
+      <xs:restriction base="xs:unsignedByte"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:unsignedByte"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedUnsignedByte"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidUnsignedByteBitLength" root="r" model="invalidUnsignedByteBitLength"
+                       description="Check for invalid bit length with an unsigned byte">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>16 out of range</tdml:error>
+      <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidLongBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedLong"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="128">
+      <xs:restriction base="xs:long"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:long"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedLong"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidLongBitLength" root="r" model="invalidLongBitLength"
+                       description="Check for invalid bit length with a long">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>128 out of range</tdml:error>
+      <tdml:error>between 1 and 64</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidIntBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedInt"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="64">
+      <xs:restriction base="xs:int"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:int"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedInt"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidIntBitLength" root="r" model="invalidIntBitLength"
+                       description="Check for invalid bit length with an int">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>64 out of range</tdml:error>
+      <tdml:error>between 1 and 32</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidShortBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedShort"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="32">
+      <xs:restriction base="xs:short"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:short"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedShort"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidShortBitLength" root="r" model="invalidShortBitLength"
+                       description="Check for invalid bit length with a short">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>32 out of range</tdml:error>
+      <tdml:error>between 1 and 16</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:defineSchema name="invalidByteBitLength">
+    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+    <dfdl:format ref="ex:GeneralFormat" representation="binary"/>
+
+    <xs:simpleType name="prefixedByte"
+                   dfdl:representation="binary"
+                   dfdl:lengthKind="explicit"
+                   dfdl:lengthUnits="bits"
+                   dfdl:length="16">
+      <xs:restriction base="xs:byte"/>
+    </xs:simpleType>
+
+    <xs:element name="r" type="xs:byte"
+                dfdl:lengthKind="prefixed"
+                dfdl:prefixLengthType="ex:prefixedByte"
+                dfdl:prefixIncludesPrefixLength="no"/>
+  </tdml:defineSchema>
+
+  <tdml:parserTestCase name="invalidByteBitLength" root="r" model="invalidByteBitLength"
+                       description="Check for invalid bit length with a byte">
+    <tdml:document>
+      <tdml:documentPart type="byte">ff</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>16 out of range</tdml:error>
+      <tdml:error>between 1 and 8</tdml:error>
+    </tdml:errors>
   </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/text_number_props/TextNumberProps.tdml
@@ -312,6 +312,15 @@
     <xs:element name="tnp100" type="xs:decimal" dfdl:textNumberPattern="##00"
       dfdl:textNumberRounding="explicit" dfdl:textNumberRoundingIncrement="1" />
 
+    <xs:element name="tnp101" type="xs:int" dfdl:textNumberPattern="###0.0##"
+      dfdl:textNumberCheckPolicy="strict" />
+
+    <xs:element name="tnp102" type="xs:double" dfdl:textNumberPattern="###0.0##"
+      dfdl:textNumberCheckPolicy="strict" />
+
+    <xs:element name="tnp103" type="xs:integer" dfdl:textNumberPattern="###0.0##"
+      dfdl:textNumberCheckPolicy="strict" />
+
   </tdml:defineSchema>
   
   <tdml:defineSchema name="textNumberPattern2"  elementFormDefault="qualified">
@@ -1503,12 +1512,12 @@
      Test Name: textStandardDecimalSeparator09
         Schema: textNumberPattern
           Root: tnp20
-       Purpose: This test demonstrates that textStandardDecimalSeparator will be ignored when the type isn't
-                decimal, float, or double
+       Purpose: This test demonstrates that textStandardDecimalSeparator is used but can be missing in the data if the type isn't
+                decimal, float, or double, as long as the fractional part is non-zero
 -->
 
   <tdml:parserTestCase name="textStandardDecimalSeparator09" root="tnp20" model="textNumberPattern"
-    description="Section 13.6 - textStandardDecimalSeparator - DFDL-13-053R">
+    description="Section 13.6 - textStandardDecimalSeparator - DFDL-13-053R" roundTrip="none">
 
     <tdml:document>
       <tdml:documentPart type="text">$5</tdml:documentPart>
@@ -1520,6 +1529,28 @@
     </tdml:infoset>
 
   </tdml:parserTestCase>
+
+<!--
+     Test Name: textStandardDecimalSeparator10
+        Schema: textNumberPattern
+          Root: tnp20
+       Purpose: This test demonstrates that textStandardDecimalSeparator is used when unparsing if the pattern specifies
+                a decimal separator, even if the type isn't decimal, float, or double
+-->
+
+  <tdml:unparserTestCase name="textStandardDecimalSeparator09u"  root="tnp20" model="textNumberPattern"
+    description="Section 13.6 - textStandardDecimalSeparator - DFDL-13-053R">
+
+    <tdml:document>
+      <tdml:documentPart type="text">$5^</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp20>5</tnp20>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+
+  </tdml:unparserTestCase>
 
   <tdml:parserTestCase name="textStandardDecimalSeparatorOneOnly1" root="tnp26" model="textNumberPattern"
     description="Section 13.6 - textStandardDecimalSeparator - DFDL-13-053R">
@@ -2850,6 +2881,17 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="nonNegIntPadding05" root="nonNegIntPad3" model="textNumberPattern"
+    description="Section 13 - Text number pattern - Padding - DFDL-13-098R">
+    <tdml:document>
+      <tdml:documentPart type="text">****begin: Inf :end</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>xs:nonNegativeInteger</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
   
   <!--
      Test Name: textNumberPattern_inputValueCalc
@@ -4039,16 +4081,13 @@
       <tdml:documentPart type="text"><![CDATA[NOTANUMBER]]]></tdml:documentPart>
     </tdml:document>
 
-    <tdml:warnings>
-      <tdml:warning>DFDL property was ignored</tdml:warning>
-      <tdml:warning>textStandardNaNRep</tdml:warning>
-    </tdml:warnings>
+    <tdml:warnings />
 
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>NaN</tdml:error>
+      <tdml:error>Out of range</tdml:error>
       <tdml:error>xs:long</tdml:error>
-      <tdml:error>NOTANUMBER</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -4061,16 +4100,13 @@
       <tdml:documentPart type="text"><![CDATA[INFINITY]]]></tdml:documentPart>
     </tdml:document>
 
-    <tdml:warnings>
-      <tdml:warning>DFDL property was ignored</tdml:warning>
-      <tdml:warning>textStandardInfinityRep</tdml:warning>
-    </tdml:warnings>
+    <tdml:warnings />
 
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>
-      <tdml:error>Unable to parse</tdml:error>
+      <tdml:error>Infinity</tdml:error>
+      <tdml:error>Out of range</tdml:error>
       <tdml:error>xs:long</tdml:error>
-      <tdml:error>INFINITY</tdml:error>
     </tdml:errors>
 
   </tdml:parserTestCase>
@@ -4368,5 +4404,104 @@
       </tdml:dfdlInfoset>
     </tdml:infoset>
   </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntWithDecimal01" root="tnp101" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">2.000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp101>2</tnp101>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="textNumberIntWithDecimal02" root="tnp101" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">2.0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp101>2</tnp101>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntWithDecimal03" root="tnp101" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">2.01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>2.01</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntWithDecimal04" root="tnp101" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">Inf</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Inf</tdml:error>
+      <tdml:error>xs:int</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberDoubleWithDecimal01" root="tnp102" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">Inf</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp102>INF</tnp102>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntegerWithDecimal01" root="tnp103" model="textNumberPattern" roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="text">9223372036854775808.000</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp103>9223372036854775808</tnp103>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:parserTestCase>
+
+  <tdml:unparserTestCase name="textNumberIntegerWithDecimal02" root="tnp103" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">9223372036854775808.0</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+        <tnp103>9223372036854775808</tnp103>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntegerWithDecimal03" root="tnp103" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">9223372036854775808.01</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>9223372036854775808.01</tdml:error>
+      <tdml:error>xs:integer</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+
+  <tdml:parserTestCase name="textNumberIntegerWithDecimal04" root="tnp103" model="textNumberPattern">
+    <tdml:document>
+      <tdml:documentPart type="text">Inf</tdml:documentPart>
+    </tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Inf</tdml:error>
+      <tdml:error>xs:integer</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section13/zoned/pv.tdml
@@ -155,6 +155,24 @@
     </infoset>
   </parserTestCase>
 
+  <parserTestCase name="vpattern_08" root="money" model="s1">
+    <document>9223372036854775808</document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:money>92233720368547758.08</ex:money>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+  <parserTestCase name="vpattern_09" root="money" model="s1">
+    <document>99.99</document>
+    <errors>
+      <error>Parse Error</error>
+      <error>Unable to parse</error>
+      <error>xs:decimal</error>
+    </errors>
+  </parserTestCase>
+
   <parserTestCase name="vpattern_zero" root="money" model="s1">
     <document>zero</document>
     <infoset>

--- a/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
+++ b/daffodil-test/src/test/resources/org/apache/daffodil/section15/choice_groups/ChoiceGroupInitiatedContent.tdml
@@ -396,17 +396,17 @@
               <xs:choice dfdl:initiatedContent="no">
 
                 <xs:element name="t0" type="xs:int"
-                  dfdl:initiator="t0:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t0:" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="t1" type="xs:int"
-                  dfdl:initiator="t1:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t1:" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="t2" type="xs:int"
-                  dfdl:initiator="t2:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t2:" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="t2f" type="xs:float"
-                  dfdl:initiator="t2:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t2:" dfdl:textNumberPattern="###.0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="t3" type="xs:int"
-                  dfdl:initiator="t3:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t3:" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="t4" type="xs:int"
-                  dfdl:initiator="t4:" dfdl:textNumberPattern="###.0" />
+                  dfdl:initiator="t4:" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict" />
                 <xs:element name="other" type="xs:string" />
               </xs:choice>
             </xs:complexType>
@@ -423,18 +423,18 @@
             dfdl:occursCountKind="parsed" dfdl:lengthKind="implicit">
             <xs:complexType>
               <xs:choice dfdl:initiatedContent="yes">
-                <xs:element name="t0" type="xs:int"
+                <xs:element name="t0" type="xs:int" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t0:" />
-                <xs:element name="t1" type="xs:int"
+                <xs:element name="t1" type="xs:int" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t1:" />
-                <xs:element name="t2" type="xs:int"
+                <xs:element name="t2" type="xs:int" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t2:" />
                 <!-- t2f can never happen because of the initiator.and initiatedContent -->
-                <xs:element name="t2f" type="xs:float"
+                <xs:element name="t2f" type="xs:float" dfdl:textNumberPattern="##0.0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t2:" />
-                <xs:element name="t3" type="xs:int"
+                <xs:element name="t3" type="xs:int" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t3:" />
-                <xs:element name="t4" type="xs:int"
+                <xs:element name="t4" type="xs:int" dfdl:textNumberPattern="##0" dfdl:textNumberCheckPolicy="strict"
                   dfdl:initiator="t4:" />
               </xs:choice>
             </xs:complexType>

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section07/variables/TestVariables.scala
@@ -163,6 +163,8 @@ class TestVariables {
     runner.runOneTest("multipleVarReadInPoU_01")
   }
 
+  @Test def test_nviInGroupDecl_01(): Unit = { runner.runOneTest("nviInGroupDecl_01") }
+
   /*****************************************************************/
   val tdmlVal = XMLUtils.TDML_NAMESPACE
   val dfdl = XMLUtils.DFDL_NAMESPACE

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindExplicit.scala
@@ -107,4 +107,50 @@ class TestLengthKindExplicit {
   @Test def test_invalidLengthUnitsDecimalWarning_explicit(): Unit = {
     runner.runOneTest("invalidLengthUnitsDecimalWarning_explicit")
   }
+
+  @Test def test_invalidUnsignedLongBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedLongBitLength")
+  }
+
+  @Test def test_invalidUnsignedLongByteLength(): Unit = {
+    runner.runOneTest("invalidUnsignedLongByteLength")
+  }
+  @Test def test_invalidUnsignedIntBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedIntBitLength")
+  }
+  @Test def test_invalidUnsignedShortBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedShortBitLength")
+  }
+  @Test def test_invalidUnsignedByteBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedByteBitLength")
+  }
+
+  @Test def test_invalidLongBitLength(): Unit = {
+    runner.runOneTest("invalidLongBitLength")
+  }
+  @Test def test_invalidIntBitLength(): Unit = {
+    runner.runOneTest("invalidIntBitLength")
+  }
+  @Test def test_invalidShortBitLength(): Unit = {
+    runner.runOneTest("invalidShortBitLength")
+  }
+  @Test def test_invalidByteBitLength(): Unit = {
+    runner.runOneTest("invalidByteBitLength")
+  }
+
+  @Test def test_invalidLongBitLengthExpr(): Unit = {
+    runner.runOneTest("invalidLongBitLengthExpr")
+  }
+
+  @Test def test_invalidIntBitLengthExpr(): Unit = {
+    runner.runOneTest("invalidIntBitLengthExpr")
+  }
+
+  @Test def test_invalidShortBitLengthExpr(): Unit = {
+    runner.runOneTest("invalidShortBitLengthExpr")
+  }
+
+  @Test def test_invalidByteBitLengthExpr(): Unit = {
+    runner.runOneTest("invalidByteBitLengthExpr")
+  }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section12/lengthKind/TestLengthKindPrefixed.scala
@@ -281,4 +281,32 @@ class TestLengthKindPrefixed {
     runner.runOneTest("invalidLengthUnits_prefixed")
   }
 
+  @Test def test_invalidUnsignedLongBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedLongBitLength")
+  }
+  @Test def test_invalidUnsignedLongByteLength(): Unit = {
+    runner.runOneTest("invalidUnsignedLongByteLength")
+  }
+  @Test def test_invalidUnsignedIntBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedIntBitLength")
+  }
+  @Test def test_invalidUnsignedShortBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedShortBitLength")
+  }
+  @Test def test_invalidUnsignedByteBitLength(): Unit = {
+    runner.runOneTest("invalidUnsignedByteBitLength")
+  }
+
+  @Test def test_invalidLongBitLength(): Unit = {
+    runner.runOneTest("invalidLongBitLength")
+  }
+  @Test def test_invalidIntBitLength(): Unit = {
+    runner.runOneTest("invalidIntBitLength")
+  }
+  @Test def test_invalidShortBitLength(): Unit = {
+    runner.runOneTest("invalidShortBitLength")
+  }
+  @Test def test_invalidByteBitLength(): Unit = {
+    runner.runOneTest("invalidByteBitLength")
+  }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/text_number_props/TestTextNumberProps.scala
@@ -280,6 +280,9 @@ class TestTextNumberProps {
   @Test def test_textStandardDecimalSeparator09(): Unit = {
     runner.runOneTest("textStandardDecimalSeparator09")
   }
+  @Test def test_textStandardDecimalSeparator09u(): Unit = {
+    runner.runOneTest("textStandardDecimalSeparator09u")
+  }
   @Test def test_textStandardDecimalSeparator12(): Unit = {
     runner.runOneTest("textStandardDecimalSeparator12")
   }
@@ -453,6 +456,7 @@ class TestTextNumberProps {
   @Test def test_nonNegIntPadding02(): Unit = { runner.runOneTest("nonNegIntPadding02") }
   @Test def test_nonNegIntPadding03(): Unit = { runner.runOneTest("nonNegIntPadding03") }
   @Test def test_nonNegIntPadding04(): Unit = { runner.runOneTest("nonNegIntPadding04") }
+  @Test def test_nonNegIntPadding05(): Unit = { runner.runOneTest("nonNegIntPadding05") }
 
   @Test def test_hexBinaryPadding01(): Unit = { runner.runOneTest("hexBinaryPadding01") }
 
@@ -488,5 +492,35 @@ class TestTextNumberProps {
   }
   @Test def test_textStandardRoundingIncrement4(): Unit = {
     runner.runOneTest("textNumberRoundingIncrement4")
+  }
+
+  @Test def test_textNumberIntWithDecimal01(): Unit = {
+    runner.runOneTest("textNumberIntWithDecimal01")
+  }
+  @Test def test_textNumberIntWithDecimal02(): Unit = {
+    runner.runOneTest("textNumberIntWithDecimal02")
+  }
+  @Test def test_textNumberIntWithDecimal03(): Unit = {
+    runner.runOneTest("textNumberIntWithDecimal03")
+  }
+  @Test def test_textNumberIntWithDecimal04(): Unit = {
+    runner.runOneTest("textNumberIntWithDecimal04")
+  }
+
+  @Test def test_textNumberDoubleWithDecimal01(): Unit = {
+    runner.runOneTest("textNumberIntWithDecimal04")
+  }
+
+  @Test def test_textNumberIntegerWithDecimal01(): Unit = {
+    runner.runOneTest("textNumberIntegerWithDecimal01")
+  }
+  @Test def test_textNumberIntegerWithDecimal02(): Unit = {
+    runner.runOneTest("textNumberIntegerWithDecimal02")
+  }
+  @Test def test_textNumberIntegerWithDecimal03(): Unit = {
+    runner.runOneTest("textNumberIntegerWithDecimal03")
+  }
+  @Test def test_textNumberIntegerWithDecimal04(): Unit = {
+    runner.runOneTest("textNumberIntegerWithDecimal04")
   }
 }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/section13/zoned/TestPV.scala
@@ -42,6 +42,8 @@ class TestPV {
   @Test def vpattern_05(): Unit = { runner.runOneTest("vpattern_05") }
   @Test def vpattern_06(): Unit = { runner.runOneTest("vpattern_06") }
   @Test def vpattern_07(): Unit = { runner.runOneTest("vpattern_07") }
+  @Test def vpattern_08(): Unit = { runner.runOneTest("vpattern_08") }
+  @Test def vpattern_09(): Unit = { runner.runOneTest("vpattern_09") }
 
   @Test def vpattern_zero(): Unit = { runner.runOneTest("vpattern_zero") }
   @Test def vpattern_ZZZ(): Unit = { runner.runOneTest("vpattern_ZZZ") }

--- a/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSepTests.scala
+++ b/daffodil-test/src/test/scala/org/apache/daffodil/usertests/TestSepTests.scala
@@ -70,6 +70,8 @@ class TestSepTests {
   @Test def test_sep_ssp_never_5(): Unit = { runner.runOneTest("test_sep_ssp_never_5") }
 
   // DAFFODIL-2791
-  // @Test def test_treatAsMissing_occursIndex(): Unit = { runner.runOneTest("test_treatAsMissing_occursIndex") }
+  @Test def test_treatAsMissing_occursIndex(): Unit = {
+    runner.runOneTest("test_treatAsMissing_occursIndex")
+  }
 
 }


### PR DESCRIPTION
Currently, if the primitive type is an integer then text number parsing disallows parsing decimal points, even if the pattern contains a decimal point.

This changes the behavior so integer parsing uses the same parsing logic as non-integer parsing (i.e. decimals are allowed), but we throw a parse error if the fractional part that was parsed in non-zero. Additionaly, if textNumberCheckPolicy is strict, we enable ICU
setDecimalPatternMatchRequired to true so that we allow or disallow decimals points in the data if the pattern does or does not have a decimal point. Note that lax parsing will always allow decimal points regardless of the pattern.

This also means that unparsing integers will now output decimal points if the pattern contains a decimal point.

One bug was discovered in ICU (ICU-22303) where if we require the decimal point due to strict mode enabled, then ICU will never parse the infinity/NaN representation. A workaround is added to manually check for these represenations until this bug is fixed. ICU unit tests are also added which should fail if ICU fixes this bug.

Also modifies NodeInfo so that fromNumber will fail for types that do not support infinity/NaN (i.e. everything except Double/Float).

DAFFODIL-2158